### PR TITLE
3.0 RC

### DIFF
--- a/source.py
+++ b/source.py
@@ -605,77 +605,39 @@ def pipeline_snr():
     print(f"Número mínimo de estágios do pipeline: {num_estagios}")
     print(f"Penalização de SNR por amplitude limitada: {penalizacao:.2f} dB")
 
+
+
 def sd_snr():
-    """Calculadora de SNR para moduladores Sigma-Delta.
-    Permite introduzir a ordem, bits do quantizador e OSR.
-    """
-
     print("\nSigma-Delta SNR Calculator")
-    print("===========================")
-
-    # Leitura dos parâmetros
-    n = int(input("Enter modulator order (e.g. 1, 2, ...): "))
-    N = int(input("Enter number of quantizer bits (e.g. 1 for 1-bit quantizer): "))
-    OSR = float(input("Enter oversampling ratio (OSR): "))
-    vin_scale = float(input("Enter signal amplitude relative to Vref (e.g. 1 for full-scale, 0.1 for Vref/10): "))
-
-    # Verifica se valores são válidos
-    if vin_scale <= 0 or vin_scale > 1:
-        print("Signal amplitude must be in (0, 1].")
-        return
-
-    # Cálculo da SNR para entrada de amplitude total
-    snr_full_scale = 6.02 * N + 1.76 + 10 * (2 * n + 1) * log10(OSR)
-
-    # Ajuste para sinal inferior a full-scale
-    snr_adjusted = snr_full_scale + 20 * log10(vin_scale)
-
-    print("\n--- Results ---")
-    print(f"SNR at full-scale input: {snr_full_scale:.2f} dB")
-    print(f"SNR with input = {vin_scale} x Vref: {snr_adjusted:.2f} dB")
+    print("================================")
+    n= int(input("n bits: "))
+    Vin = float(input("Introduz Vin (em volts): "))
+    osr = float(input("Introduz o OSR: "))
+    order = int(input("Introduz a ordem: "))
+    if order==1:
+        snr = 6.02 * n + 1.76 + 30 * log10(osr) - 5.17 + 20 * log10(Vin)
+    if order==2:
+        snr2 = 6.02 * n + 1.76 + 50 * log10(osr) - 12.9 + 20 * log10(Vin) 
+    print(f"\nSNR calculado: {snr:.2f} dB")
+    print(f"SNR calculado (2ª ordem): {snr2:.2f} dB")
     
 
 
 def sd_osr():
-    """Calculadora de OSR para moduladores Sigma-Delta.
-    Inclui fator de ruído para entrada senoidal e modulação 1-bit.
-    """
-
-    print("\nSigma-Delta OSR Calculator")
-    print("==============================================")
-
-    # Leitura dos parâmetros
-    n = int(input("Enter modulator order: "))
-    N = int(input("Enter number of quantizer bits: "))
-    target_snr = float(input("Enter desired SNR in dB: "))
-    vin_scale = float(input("Enter signal amplitude relative to Vref (e.g. 1 for full-scale, 0.1 for Vref/10): "))
-
-    # Verifica validade
-    if vin_scale <= 0 or vin_scale > 1:
-        print("Signal amplitude must be in (0, 1].")
-        return
-
-    # Constante de ruído para entrada sinusoidal
-    noise_constant = 10 * log10(3 / (pi ** 2))  # ≈ -5.23 dB
-
-    # Cálculo da SNR base (sem OSR)
-    base_snr = 6.02 * N + 1.76 + 20 * log10(vin_scale) + noise_constant
-
-    # Parte variável
-    delta_snr = target_snr - base_snr
-
-    if delta_snr <= 0:
-        print("Desired SNR is too low for the given signal amplitude and quantizer.")
-        return
-
-    # Cálculo da OSR
-    osr = 10 ** (delta_snr / (10 * (2 * n + 1)))
-
-    print("\n--- Results ---")
-    print(f"Minimum required OSR: {osr:.4f}")
-
+    """Calculadora de OSR para modulador Sigma-Delta baseada em V_REF, V_lsb e SNR alvo."""
+    print("\nSigma-Delta OSR Calculator (com V_REF e V_lsb)")
+    print("===============================================")
+    order = int(input("Introduz a ordem do modulador Sigma-Delta (1 ou 2): "))
+    snr=float(input("Introduz o SNR alvo (em dB): "))
+    n= int(input("Introduz o número de bits do quantizador (e.g. 1 ou 3): "))
+    Vin = float(input("Introduz Vin (em volts): "))
     
-
+    osr = 10**((snr-1.76-6.02*n+5.17-20*log10(Vin))/30)
+    #elif order == 2:
+    #    osr = 10**(((snr-20*log10(Vin))-1.76-6.02*n+5.17-20*log10(Vin))/30)
+    print(f"\nOSR necessário para atingir SNR de {snr} dB: {osr:.3f}")
+    
+    
 def main():
     """Função de menu principal
     

--- a/source.py
+++ b/source.py
@@ -617,9 +617,10 @@ def sd_snr():
     if order==1:
         snr = 6.02 * n + 1.76 + 30 * log10(osr) - 5.17 + 20 * log10(Vin)
     if order==2:
-        snr2 = 6.02 * n + 1.76 + 50 * log10(osr) - 12.9 + 20 * log10(Vin) 
+        snr = 6.02 * n + 1.76 + 50 * log10(osr) - 12.9 + 20 * log10(Vin) 
+    if order==3:
+        snr = 6.02 * n + 1.76 + 70 * log10(osr) - 20.9 + 20 * log10(Vin)
     print(f"\nSNR calculado: {snr:.2f} dB")
-    print(f"SNR calculado (2ª ordem): {snr2:.2f} dB")
     
 
 
@@ -632,9 +633,13 @@ def sd_osr():
     n= int(input("Introduz o número de bits do quantizador (e.g. 1 ou 3): "))
     Vin = float(input("Introduz Vin (em volts): "))
     
-    osr = 10**((snr-1.76-6.02*n+5.17-20*log10(Vin))/30)
-    #elif order == 2:
-    #    osr = 10**(((snr-20*log10(Vin))-1.76-6.02*n+5.17-20*log10(Vin))/30)
+    if order==1:
+        osr = 10**((snr-1.76-6.02*n+5.17-20*log10(Vin))/30)
+    if order==2:
+        osr = 10**((snr-1.76-6.02*n+12.9-20*log10(Vin))/50)
+    if order==3:
+        osr = 10**((snr-1.76-6.02*n+20.9-20*log10(Vin))/70)
+    
     print(f"\nOSR necessário para atingir SNR de {snr} dB: {osr:.3f}")
     
     

--- a/source.py
+++ b/source.py
@@ -635,6 +635,47 @@ def sd_snr():
     print(f"SNR with input = {vin_scale} x Vref: {snr_adjusted:.2f} dB")
     
 
+
+def sd_osr():
+    """Calculadora de OSR para moduladores Sigma-Delta.
+    Inclui fator de ruído para entrada senoidal e modulação 1-bit.
+    """
+
+    print("\nSigma-Delta OSR Calculator")
+    print("==============================================")
+
+    # Leitura dos parâmetros
+    n = int(input("Enter modulator order: "))
+    N = int(input("Enter number of quantizer bits: "))
+    target_snr = float(input("Enter desired SNR in dB: "))
+    vin_scale = float(input("Enter signal amplitude relative to Vref (e.g. 1 for full-scale, 0.1 for Vref/10): "))
+
+    # Verifica validade
+    if vin_scale <= 0 or vin_scale > 1:
+        print("Signal amplitude must be in (0, 1].")
+        return
+
+    # Constante de ruído para entrada sinusoidal
+    noise_constant = 10 * log10(3 / (pi ** 2))  # ≈ -5.23 dB
+
+    # Cálculo da SNR base (sem OSR)
+    base_snr = 6.02 * N + 1.76 + 20 * log10(vin_scale) + noise_constant
+
+    # Parte variável
+    delta_snr = target_snr - base_snr
+
+    if delta_snr <= 0:
+        print("Desired SNR is too low for the given signal amplitude and quantizer.")
+        return
+
+    # Cálculo da OSR
+    osr = 10 ** (delta_snr / (10 * (2 * n + 1)))
+
+    print("\n--- Results ---")
+    print(f"Minimum required OSR: {osr:.4f}")
+
+    
+
 def main():
     """Função de menu principal
     
@@ -704,9 +745,12 @@ def main():
             elif choice == 6:
                 print("Sigma-Delta Tools")
                 print("1. SD SNR")
+                print("2. OSR")
                 sigma_delta_choice = int(input("Enter your choice (1-3): "))
                 if sigma_delta_choice == 1:
                     sd_snr()
+                if sigma_delta_choice == 2:
+                    sd_osr()
                 else:
                     print("Invalid choice. Please try again.")
                 

--- a/source.py
+++ b/source.py
@@ -605,6 +605,34 @@ def pipeline_snr():
     print(f"Número mínimo de estágios do pipeline: {num_estagios}")
     print(f"Penalização de SNR por amplitude limitada: {penalizacao:.2f} dB")
 
+def sd_snr():
+    """Calculadora de SNR para moduladores Sigma-Delta.
+    Permite introduzir a ordem, bits do quantizador e OSR.
+    """
+
+    print("\nSigma-Delta SNR Calculator")
+    print("===========================")
+
+    # Leitura dos parâmetros
+    n = int(input("Enter modulator order (e.g. 1, 2, ...): "))
+    N = int(input("Enter number of quantizer bits (e.g. 1 for 1-bit quantizer): "))
+    OSR = float(input("Enter oversampling ratio (OSR): "))
+    vin_scale = float(input("Enter signal amplitude relative to Vref (e.g. 1 for full-scale, 0.1 for Vref/10): "))
+
+    # Verifica se valores são válidos
+    if vin_scale <= 0 or vin_scale > 1:
+        print("Signal amplitude must be in (0, 1].")
+        return
+
+    # Cálculo da SNR para entrada de amplitude total
+    snr_full_scale = 6.02 * N + 1.76 + 10 * (2 * n + 1) * log10(OSR)
+
+    # Ajuste para sinal inferior a full-scale
+    snr_adjusted = snr_full_scale + 20 * log10(vin_scale)
+
+    print("\n--- Results ---")
+    print(f"SNR at full-scale input: {snr_full_scale:.2f} dB")
+    print(f"SNR with input = {vin_scale} x Vref: {snr_adjusted:.2f} dB")
     
 
 def main():
@@ -626,6 +654,7 @@ def main():
         print("3. SNR Tools")
         print("4. Pipeline Tools")
         print("5. Clock Frequency Calculator")
+        print("6. Sigma-Delta Tools")
         
         print("0. Exit")
         print("----------------------------------")
@@ -671,6 +700,15 @@ def main():
                     
             elif choice == 5:
                 clock_freq_calculator()
+                
+            elif choice == 6:
+                print("Sigma-Delta Tools")
+                print("1. SD SNR")
+                sigma_delta_choice = int(input("Enter your choice (1-3): "))
+                if sigma_delta_choice == 1:
+                    sd_snr()
+                else:
+                    print("Invalid choice. Please try again.")
                 
             else:
                 print("Invalid option. Please try again.")

--- a/source.py
+++ b/source.py
@@ -610,36 +610,37 @@ def pipeline_snr():
 def sd_snr():
     print("\nSigma-Delta SNR Calculator")
     print("================================")
-    n= int(input("n bits: "))
+    n = int(input("n bits: "))
     Vin = float(input("Introduz Vin (em volts): "))
     osr = float(input("Introduz o OSR: "))
-    order = int(input("Introduz a ordem: "))
-    if order==1:
-        snr = 6.02 * n + 1.76 + 30 * log10(osr) - 5.17 + 20 * log10(Vin)
-    if order==2:
-        snr = 6.02 * n + 1.76 + 50 * log10(osr) - 12.9 + 20 * log10(Vin) 
-    if order==3:
-        snr = 6.02 * n + 1.76 + 70 * log10(osr) - 20.9 + 20 * log10(Vin)
-    print(f"\nSNR calculado: {snr:.2f} dB")
-    
+    order = int(input("Introduz a ordem (1, 2 ou 3): "))
 
+    if order not in [1, 2, 3]:
+        print("Erro: ordem inválida.")
+        return
+
+    gains = {1: 30, 2: 50, 3: 70}
+    corrections = {1: -5.17, 2: -12.9, 3: -20.9}
+
+    snr = 6.02 * n + 1.76 + gains[order] * log10(osr) + corrections[order] + 20 * log10(Vin)
+    print(f"\nSNR calculado: {snr:.2f} dB")
 
 def sd_osr():
-    """Calculadora de OSR para modulador Sigma-Delta baseada em V_REF, V_lsb e SNR alvo."""
     print("\nSigma-Delta OSR Calculator (com V_REF e V_lsb)")
     print("===============================================")
-    order = int(input("Introduz a ordem do modulador Sigma-Delta (1 ou 2): "))
-    snr=float(input("Introduz o SNR alvo (em dB): "))
-    n= int(input("Introduz o número de bits do quantizador (e.g. 1 ou 3): "))
+    order = int(input("Introduz a ordem do modulador Sigma-Delta (1, 2 ou 3): "))
+    snr = float(input("Introduz o SNR alvo (em dB): "))
+    n = int(input("Introduz o número de bits do quantizador (e.g. 1 ou 3): "))
     Vin = float(input("Introduz Vin (em volts): "))
-    
-    if order==1:
-        osr = 10**((snr-1.76-6.02*n+5.17-20*log10(Vin))/30)
-    if order==2:
-        osr = 10**((snr-1.76-6.02*n+12.9-20*log10(Vin))/50)
-    if order==3:
-        osr = 10**((snr-1.76-6.02*n+20.9-20*log10(Vin))/70)
-    
+
+    if order not in [1, 2, 3]:
+        print("Erro: ordem inválida.")
+        return
+
+    gains = {1: 30, 2: 50, 3: 70}
+    corrections = {1: -5.17, 2: -12.9, 3: -20.9}
+
+    osr = 10**((snr - 1.76 - 6.02 * n - corrections[order] - 20 * log10(Vin)) / gains[order])
     print(f"\nOSR necessário para atingir SNR de {snr} dB: {osr:.3f}")
     
     


### PR DESCRIPTION
This pull request introduces new Sigma-Delta tools to the `source.py` file, enhancing its functionality by adding calculators for Sigma-Delta Signal-to-Noise Ratio (SNR) and Oversampling Ratio (OSR). Additionally, the main menu is updated to include these new tools, along with corresponding logic for user interaction.

### New Sigma-Delta Tools:

* Added `sd_snr()` function to calculate the Sigma-Delta Signal-to-Noise Ratio (SNR) based on user inputs such as bit resolution, input voltage, oversampling ratio (OSR), and modulator order. The function validates the order and computes the SNR using predefined gains and corrections.
* Added `sd_osr()` function to calculate the required Oversampling Ratio (OSR) to achieve a target SNR, using user inputs like modulator order, target SNR, quantizer bits, and input voltage. The function validates the order and computes the OSR using predefined gains and corrections.

### Main Menu Updates:

* Updated the main menu in `main()` to include an option for "Sigma-Delta Tools."
* Added logic to handle the new "Sigma-Delta Tools" menu option, allowing users to choose between the SNR and OSR calculators. Input validation ensures appropriate feedback for invalid choices.